### PR TITLE
Fix CITATION.cff, add validator & formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,22 @@ repos:
     hooks:
       - id: "black"
 
+  # Format and validate CFF. NOTE: pre-commit doesn't recognize CFF as YAML
+  # (https://github.com/pre-commit/identify/pull/435), so we may need to
+  # specify the prettier hook twice if we want to format other things and avoid
+  # a messy regex.
+  - repo: "https://github.com/pre-commit/mirrors-prettier"
+    rev: "v3.1.0"
+    hooks:
+      - id: "prettier"
+        files: "CITATION.cff"
+  - repo: "https://github.com/citation-file-format/cffconvert"
+    rev: "054bda51dbe278b3e86f27c890e3f3ac877d616c"
+    hooks:
+      - id: "validate-cff"
+        args:
+          - "--verbose"
+
   #  TODO: Enable vulture
   # - repo: "https://github.com/jendrikseipp/vulture"
   #   rev: "v2.7"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,26 +1,29 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
-  
+
 title: "US Arctic Observation Network Benefit Tool"
 doi: "10.5281/zenodo.8403759"
 
 type: "software"
-license: ["MIT"]
+# NOTE: The CFF spec says `license` can be a list, but Zenodo is currently not
+# happy with lists:
+#    https://github.com/zenodo/zenodo/issues/2515
+license: "MIT"
 
 version: 1.1.0
 date-released: "2023-11-01"
 url: "https://github.com/nsidc/usaon-vta-survey"
-  
+
 authors:
-- family-names: "Marowitz"
-  given-names: "Robyn"
-  orcid: "https://orcid.org/0000-0003-3160-132X"
-- family-names: "Fisher"
-  given-names: "Matt"
-  orcid: "https://orcid.org/0000-0003-3260-5445"
+  - family-names: "Marowitz"
+    given-names: "Robyn"
+    orcid: "https://orcid.org/0000-0003-3160-132X"
+  - family-names: "Fisher"
+    given-names: "Matt"
+    orcid: "https://orcid.org/0000-0003-3260-5445"
   - family-names: "Shapiro"
-  given-names: "Hazel"
-  orcid: "https://orcid.org/0000-0001-5490-7124"
+    given-names: "Hazel"
+    orcid: "https://orcid.org/0000-0001-5490-7124"
   - family-names: "Starkweather"
-  given-names: "Sandy"
-  orcid: "https://orcid.org/0000-0001-7369-1891"
+    given-names: "Sandy"
+    orcid: "https://orcid.org/0000-0001-7369-1891"


### PR DESCRIPTION
We have some errors of our own, but also a Zenodo parsing bug (#198). This PR fixes both, and adds validators so we can't add new errors!