### PR TITLE
Use pre-commit.ci for running our pre-commit hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,6 @@ jobs:
           # Increase this key to trigger cache invalidation
           cache-environment-key: 0
 
-      - name: "Run pre-commit checks"
-        run: "pre-commit run --all-files --show-diff-on-failure --color always"
-
       - name: "Run tests"
         run: "inv test"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
+ci:
+  autoupdate_schedule: "monthly"
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_prs: false # Comment "pre-commit.ci autofix" on a PR to trigger
+
+
 default_language_version:
   python: "python3.10"
-
 
 repos:
 


### PR DESCRIPTION
This is faster. pre-commit.ci will also provide some useful autoupdate features. There should be a few bot PRs soon after this is merged. Or before. I don't know :P 

After this is merged, you can comment with the text "pre-commit.ci autofix" (without quotes) on its own line in any PR and the bot will come through and push a commit which fixes everything it knows how to fix. This can include, for example markdown formatting. @hazelshapiro you may find that feature useful at some point!